### PR TITLE
[PC-1930] Improve Github Authentication tokens

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,8 +1,17 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_ssm_parameter" "this" {
-  name = var.ssm_parameter_name
+data "aws_ssm_parameter" "github_app_client_id" {
+  name = var.ssm_github_app_client_id
 }
+
+data "aws_ssm_parameter" "github_app_installation_id" {
+  name = var.ssm_github_app_installation_id
+}
+
+data "aws_ssm_parameter" "github_app_private_key" {
+  name = var.ssm_github_app_private_key
+}
+
 
 data "aws_ec2_instance_type" "this" {
   instance_type = var.ec2_instance_type

--- a/main.tf
+++ b/main.tf
@@ -22,9 +22,13 @@ resource "aws_iam_policy" "this" {
     Version = "2012-10-17"
     Statement = concat([
       {
-        Action   = ["ssm:GetParameter*"]
-        Effect   = "Allow"
-        Resource = data.aws_ssm_parameter.this.arn
+        Action = ["ssm:GetParameter*"]
+        Effect = "Allow"
+        Resource = [
+          data.aws_ssm_parameter.github_app_client_id.arn,
+          data.aws_ssm_parameter.github_app_installation_id.arn,
+          data.aws_ssm_parameter.github_app_private_key.arn
+        ]
       },
       {
         Action   = ["ec2:CreateTags"]
@@ -159,7 +163,9 @@ module "user_data" {
     runner_group  = var.github_runner_group
     runner_labels = var.github_runner_labels
 
-    ssm_parameter_name = var.ssm_parameter_name
+    ssm_github_app_client_id       = var.ssm_github_app_client_id
+    ssm_github_app_installation_id = var.ssm_github_app_installation_id
+    ssm_github_app_private_key     = var.ssm_github_app_private_key
   }
 }
 
@@ -187,9 +193,9 @@ resource "aws_launch_template" "this" {
   image_id = data.aws_ami.ami.id
 
 
-# instance_market_options {
-#   market_type = "spot"
-# }
+  instance_market_options {
+    market_type = "spot"
+  }
 
   instance_type = var.ec2_instance_type
 

--- a/modules/user_data/cloud-init-ephemeral.yaml
+++ b/modules/user_data/cloud-init-ephemeral.yaml
@@ -31,11 +31,53 @@ write_files:
     [ "$#" -eq 1 ] || die "1 argument required, $# provided."
     RUN=$1
     cp -R /home/ubuntu/actions-runner /home/ubuntu/actions-runner-$RUN
-    PERSONAL_ACCESS_TOKEN=`aws ssm get-parameter --with-decryption --name ${SSM_PARAMETER_NAME} --region ${REGION} | jq -r '.Parameter.Value'`
-    [ "$PERSONAL_ACCESS_TOKEN" != "" ] || die "Unable to retrieve access token."
-    TOKEN_RESPONSE=`curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $PERSONAL_ACCESS_TOKEN" "https://api.github.com/orgs/${GITHUB_ORGANISATION_NAME}/actions/runners/registration-token"`
+
+    GITHUB_APP_CLIENT_ID=`aws ssm get-parameter --with-decryption --name ${SSM_GITHUB_APP_CLIENT_ID} --region ${REGION} | jq -r '.Parameter.Value'`
+    GITHUB_APP_PRIVATE_KEY=`aws ssm get-parameter --with-decryption --name ${SSM_GITHUB_APP_PRIVATE_KEY} --region ${REGION} | jq -r '.Parameter.Value'`
+    GITHUB_APP_INSTALLATION_ID=`aws ssm get-parameter --with-decryption --name ${SSM_GITHUB_APP_INSTALLATION_ID} --region ${REGION} | jq -r '.Parameter.Value'`
+
+    client_id=$GITHUB_APP_CLIENT_ID
+    pem=$GITHUB_APP_PRIVATE_KEY
+    
+    now=$(date +%s)
+    iat=$(($now - 60)) # Issues 60 seconds in the past
+    exp=$(($now + 600)) # Expires 10 minutes in the future
+    
+    b64enc() { openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'; }
+    
+    header_json='{
+        "typ":"JWT",
+        "alg":"RS256"
+    }'
+    # Header encode
+    header=$( echo -n "$header_json" | b64enc )
+    
+    payload_json="{
+        \"iat\":$iat,
+        \"exp\":$exp,
+        \"iss\":\"$client_id\"
+    }"
+    # Payload encode
+    payload=$( echo -n "$payload_json" | b64enc )
+    
+    # Signature
+    header_payload="$header"."$payload"
+    signature=$(
+        openssl dgst -sha256 -sign <(echo -n "$pem") \
+        <(echo -n "$header_payload") | b64enc
+    )
+   
+    # Github APP is a JWT token using the Private Key generate in Github and the Client ID.
+    GITHUB_JWT_TOKEN="$header_payload"."$signature"
+    
+    [ "$GITHUB_JWT_TOKEN" != "" ] || die "Unable to retrieve access token."
+    GITHUB_APP_TOKEN_RESPONSE=`curl -s -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_JWT_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/app/installations/$GITHUB_APP_INSTALLATION_ID/access_tokens"`
+    GITHUB_AUTH_GITHUB_RUNNER=`echo $GITHUB_APP_TOKEN_RESPONSE | jq -r '.token'`
+   
+    TOKEN_RESPONSE=`curl --request POST --url "https://api.github.com/orgs/${GITHUB_ORGANISATION_NAME}/actions/runners/registration-token" --header "Accept: application/vnd.github+json" --header "Authorization: Bearer $GITHUB_AUTH_GITHUB_RUNNER"`
     TOKEN=`echo $TOKEN_RESPONSE | jq -r '.token'`
     [ "$TOKEN" != "null" ] || die "Unable to retrieve token."
+
     NAME=`hostname`-run-$RUN
     echo NAME=$NAME
     /home/ubuntu/actions-runner-$RUN/config.sh --url '${GITHUB_URL}' --ephemeral --disableupdate --token $TOKEN --name $NAME ${ARG_RUNNERGROUP} ${ARG_LABELS}

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -3,9 +3,11 @@ locals {
 
   user_data = templatefile(
     "${path.module}/cloud-init-ephemeral.yaml", {
-      REGION               = var.config.region
-      SSM_PARAMETER_NAME   = var.config.ssm_parameter_name
-      CLOUDWATCH_LOG_GROUP = var.config.cloudwatch_log_group
+      REGION                         = var.config.region
+      SSM_GITHUB_APP_CLIENT_ID       = var.config.ssm_github_app_client_id
+      SSM_GITHUB_APP_INSTALLATION_ID = var.config.ssm_github_app_installation_id
+      SSM_GITHUB_APP_PRIVATE_KEY     = var.config.ssm_github_app_private_key
+      CLOUDWATCH_LOG_GROUP           = var.config.cloudwatch_log_group
 
       PACKAGES    = var.config.cloud_init_packages
       RUNCMDS     = var.config.cloud_init_runcmds

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -1,8 +1,10 @@
 variable "config" {
   type = object({
-    region               = string
-    ssm_parameter_name   = string
-    cloudwatch_log_group = string
+    region                         = string
+    ssm_github_app_installation_id = string
+    ssm_github_app_client_id       = string
+    ssm_github_app_private_key     = string
+    cloudwatch_log_group           = string
 
     cloud_init_packages    = list(string)
     cloud_init_runcmds     = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,16 @@
 # Required variables
-variable "ssm_parameter_name" {
-  description = "SSM parameter name for the GitHub Runner token.<br>Example: `\"/github/runner/token\"`."
+variable "ssm_github_app_client_id" {
+  description = "SSM parameter for the GitHub Runner client ID.<br>Example: `\"/github/runner/client-id\"`."
+  type        = string
+}
+
+variable "ssm_github_app_installation_id" {
+  description = "SSM parameter for the GitHub Runner installation ID.<br>Example: `\"/github/runner/installation-id\"`."
+  type        = string
+}
+
+variable "ssm_github_app_private_key" {
+  description = "SSM parameter for the GitHub Runner private key.<br>Example: `\"/github/runner/private-key\"`."
   type        = string
 }
 


### PR DESCRIPTION
# Description

The upstream implementation uses PAT token. This is a personal token under the user and it has security implications. The best option is to use `Github App` that needs to be created manually under the Organization.

Once you created you need to install it under the organization. Permissions are scoped.  This will create a JWT token based on a Private Key (needs to be generated at the end of the Github Application and downloaded)

![github-app](https://github.com/user-attachments/assets/15b0c195-a6d2-49c3-a97f-24400f88570c)

This PR includes the modifications required changes. This means some new endpoints and storing values in SSM.

![github-app-secret-store](https://github.com/user-attachments/assets/722b9f5d-d206-4307-bdd8-b992624562b4)

[Github Documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#example-using-bash-to-generate-a-jwt)
