### PR TITLE
[E2E-1083] chore: update aws provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,46 +2,55 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.2.0](https://github.com/cloudandthings/terraform-aws-github-runners/compare/v1.1.1...v1.2.0) (2023-02-10)
+## [1.4.0](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.3.0...v1.4.0) (2025-11-12)
+### Features
+* Update terraform provider to v5
 
+## [1.3.0](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.2.0...1.3.0) (2024-08-08)
+### Features
+* Update AWS cli to v2
+* Update kubectl to 1.28.13
+* Disable spot instance
+* Improve github tokens auth
 
+## [1.2.0](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.1.1...v1.2.0) (2023-02-10)
 ### Features
 
-* Add `create_instance_profile` ([#38](https://github.com/cloudandthings/terraform-aws-github-runners/issues/38)) ([b3c278d](https://github.com/cloudandthings/terraform-aws-github-runners/commit/b3c278d568ec5ad575e7e1a5ce659067bcedf9b1))
-* Add BASE_PACKAGES software pack ([6dbee94](https://github.com/cloudandthings/terraform-aws-github-runners/commit/6dbee94e533ec03517cf054b988bcbeed0a5b416))
-* Add iam_policy_arns variable ([9037423](https://github.com/cloudandthings/terraform-aws-github-runners/commit/9037423ad4bdfc4cd402c15abc8a2b0162686f17))
+* Add `create_instance_profile` ([#38](https://github.com/Ebury/terraform-aws-github-runners/issues/38)) ([b3c278d](https://github.com/Ebury/terraform-aws-github-runners/commit/b3c278d568ec5ad575e7e1a5ce659067bcedf9b1))
+* Add BASE_PACKAGES software pack ([6dbee94](https://github.com/Ebury/terraform-aws-github-runners/commit/6dbee94e533ec03517cf054b988bcbeed0a5b416))
+* Add iam_policy_arns variable ([9037423](https://github.com/Ebury/terraform-aws-github-runners/commit/9037423ad4bdfc4cd402c15abc8a2b0162686f17))
 
 
 ### Bug Fixes
 
-* Improved default concurrency ([bc3821d](https://github.com/cloudandthings/terraform-aws-github-runners/commit/bc3821d66df152a07d0c89811e6e4258d6e32892))
+* Improved default concurrency ([bc3821d](https://github.com/Ebury/terraform-aws-github-runners/commit/bc3821d66df152a07d0c89811e6e4258d6e32892))
 
-### [1.1.1](https://github.com/cloudandthings/terraform-aws-github-runners/compare/v1.1.0...v1.1.1) (2022-12-14)
+### [1.1.1](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.1.0...v1.1.1) (2022-12-14)
 
 
 ### Bug Fixes
 
-* **python3:** Add python-dev-is-python3 package ([#34](https://github.com/cloudandthings/terraform-aws-github-runners/issues/34)) ([e74b64a](https://github.com/cloudandthings/terraform-aws-github-runners/commit/e74b64a983a0dca8455c2752fe0d7ffe949dbfcb))
+* **python3:** Add python-dev-is-python3 package ([#34](https://github.com/Ebury/terraform-aws-github-runners/issues/34)) ([e74b64a](https://github.com/Ebury/terraform-aws-github-runners/commit/e74b64a983a0dca8455c2752fe0d7ffe949dbfcb))
 
-## [1.1.0](https://github.com/cloudandthings/terraform-aws-github-runners/compare/v1.0.1...v1.1.0) (2022-12-08)
+## [1.1.0](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.0.1...v1.1.0) (2022-12-08)
 
 
 ### Features
 
-* **software:** Added tfsec ([#33](https://github.com/cloudandthings/terraform-aws-github-runners/issues/33)) ([1e73b96](https://github.com/cloudandthings/terraform-aws-github-runners/commit/1e73b964669e9ba41772e5e910811af6fb009958))
+* **software:** Added tfsec ([#33](https://github.com/Ebury/terraform-aws-github-runners/issues/33)) ([1e73b96](https://github.com/Ebury/terraform-aws-github-runners/commit/1e73b964669e9ba41772e5e910811af6fb009958))
 
 ## 1.0.0 (2022-09-30)
 
 
 ### Features
 
-* Initial commit ([4fb431b](https://github.com/cloudandthings/terraform-aws-github-runners/commit/4fb431bf4666acbbcb36ac4eceea0304b226e54f))
-* Initial commit ([c7bdca2](https://github.com/cloudandthings/terraform-aws-github-runners/commit/c7bdca2a69e4c06ef3cee669a6523e8f0936fb93))
+* Initial commit ([4fb431b](https://github.com/Ebury/terraform-aws-github-runners/commit/4fb431bf4666acbbcb36ac4eceea0304b226e54f))
+* Initial commit ([c7bdca2](https://github.com/Ebury/terraform-aws-github-runners/commit/c7bdca2a69e4c06ef3cee669a6523e8f0936fb93))
 
 
 ### Bug Fixes
 
-* Auto release process ([#30](https://github.com/cloudandthings/terraform-aws-github-runners/issues/30)) ([c18832d](https://github.com/cloudandthings/terraform-aws-github-runners/commit/c18832d8601e41276027ba4f63482d078703cd99))
+* Auto release process ([#30](https://github.com/Ebury/terraform-aws-github-runners/issues/30)) ([c18832d](https://github.com/Ebury/terraform-aws-github-runners/commit/c18832d8601e41276027ba4f63482d078703cd99))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.0](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.3.0...v1.4.0) (2025-11-12)
+## [1.3.2](https://github.com/Ebury/terraform-aws-github-runners/compare/v1.3.0...v1.3.2) (2025-11-12)
 ### Features
 * Update terraform provider to v5
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Simple to use, self-hosted GitHub Action runners. Uses EC2 spot instances with configurable AutoScaling.
 
-[![GitHub repo link](https://github.com/cloudandthings/terraform-aws-github-runners/blob/main/docs/images/icon.gif )](https://github.com/cloudandthings/terraform-aws-github-runners)
+[![GitHub repo link](https://github.com/Ebury/terraform-aws-github-runners/blob/main/docs/images/icon.gif )](https://github.com/Ebury/terraform-aws-github-runners)
 
 ---
 
-[![Maintenance](https://img.shields.io/badge/Maintained-yes-green.svg)](https://github.com/cloudandthings/terraform-aws-github-runners/graphs/commit-activity)
-[![Test Status](https://github.com/cloudandthings/terraform-aws-github-runners/actions/workflows/main.yml/badge.svg)](https://github.com/cloudandthings/terraform-aws-github-runners/actions/workflows/main.yml)
+[![Maintenance](https://img.shields.io/badge/Maintained-yes-green.svg)](https://github.com/Ebury/terraform-aws-github-runners/graphs/commit-activity)
+[![Test Status](https://github.com/Ebury/terraform-aws-github-runners/actions/workflows/main.yml/badge.svg)](https://github.com/Ebury/terraform-aws-github-runners/actions/workflows/main.yml)
 ![Terraform Version](https://img.shields.io/badge/tf-%3E%3D0.13.0-blue)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
@@ -41,7 +41,7 @@ A possible workaround could be to [run jobs in a container](https://docs.github.
 
 ## How it works
 
-[![Infrastructure diagram](https://github.com/cloudandthings/terraform-aws-github-runners/blob/main/docs/images/runner.svg)](https://github.com/cloudandthings/terraform-aws-github-runners/blob/main/docs/images/runner.svg)
+[![Infrastructure diagram](https://github.com/Ebury/terraform-aws-github-runners/blob/main/docs/images/runner.svg)](https://github.com/Ebury/terraform-aws-github-runners/blob/main/docs/images/runner.svg)
 
 An AutoScaling group is created to spin up Spot EC2 instances on a schedule. The instances retrieve a pre-configured GitHub access token from AWS SSM Parameter Store, and start one (or more) ephemeral actions runner processes. These authenticate with GitHub and wait for work.
 
@@ -61,7 +61,7 @@ A full list of created resources is shown below.
 Create a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 Add it to AWS Systems Manager Parameter Store with the `SecureString` type.
 
-[![Parameter Store configuration](https://github.com/cloudandthings/terraform-aws-github-runners/blob/main/docs/images/ssm.png)](https://github.com/cloudandthings/terraform-aws-github-runners/blob/main/docs/images/ssm.png )
+[![Parameter Store configuration](https://github.com/Ebury/terraform-aws-github-runners/blob/main/docs/images/ssm.png)](https://github.com/Ebury/terraform-aws-github-runners/blob/main/docs/images/ssm.png )
 
 
 ### 2. Configure module
@@ -69,8 +69,8 @@ Configure and deploy the module using Terraform. See examples below.
 
 ## More info
 
-- Found an issue? Want to help? [Contribute](https://github.com/cloudandthings/terraform-aws-github-runners/.github/contribute.md).
-- Review a [cost estimate](https://github.com/cloudandthings/terraform-aws-github-runners/blob/main/docs/cost_estimate.md).
+- Found an issue? Want to help? [Contribute](https://github.com/Ebury/terraform-aws-github-runners/.github/contribute.md).
+- Review a [cost estimate](https://github.com/Ebury/terraform-aws-github-runners/blob/main/docs/cost_estimate.md).
 
 <!-- BEGIN_TF_DOCS -->
 ## Module Docs

--- a/docs/test_badges.md
+++ b/docs/test_badges.md
@@ -1,3 +1,3 @@
-[![Latest Release](https://img.shields.io/github/release/cloudandthings/terraform-aws-github-runners)](https://github.com/cloudandthings/terraform-aws-github-runners/releases/latest)
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/cloudandthings/terraform-aws-github-runners?label=latest)](https://github.com/cloudandthings/terraform-aws-github-runners/releases/latest)
-[![Github All Releases](https://img.shields.io/github/downloads/cloudandthings/terraform-aws-github-runners/total)](https://github.com/cloudandthings/terraform-aws-github-runners/releases)
+[![Latest Release](https://img.shields.io/github/release/Ebury/terraform-aws-github-runners)](https://github.com/Ebury/terraform-aws-github-runners/releases/latest)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/Ebury/terraform-aws-github-runners?label=latest)](https://github.com/Ebury/terraform-aws-github-runners/releases/latest)
+[![Github All Releases](https://img.shields.io/github/downloads/Ebury/terraform-aws-github-runners/total)](https://github.com/Ebury/terraform-aws-github-runners/releases)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.9"
+      version = "~> 6.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 5.85"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
This is only used from terraform-ci repo based on a search: https://github.com/search?q=org%3AEbury+terraform-aws-github-runners+NOT+language%3AMarkdown&type=code

<img width="1008" height="786" alt="image" src="https://github.com/user-attachments/assets/a40d8a31-0fc7-4aaa-842f-41ef8fc24a45" />

I had to update this provider because the directory that is consuming this module in terraform-ci, also started using terraform-module-github-runners, which requires AWS v5 or above.
